### PR TITLE
Remove instructions for post-deploy prisma hook

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -64,22 +64,6 @@ prisma generate
 
 </Instruction>
 
-Right now, it is a bit annoying that you need to explicitly run `prisma generate` every time you're migrating your database with `prisma deploy`. To make that easier in the future, you can configure a [post-deployment hook](https://www.prisma.io/docs/prisma-cli-and-configuration/prisma-yml-5cy7/#hooks-optional) that gets invoked every time after you ran `prisma deploy`.
-
-<Instruction>
-
-Add the following lines to the end of your `prisma.yml`:
-
-```yml(path=".../hackernews-node/prisma/prisma.yml")
-hooks:
-  post-deploy:
-    - prisma generate
-```
-
-</Instruction>
-
-The Prisma client will now automatically be regenerated upon a datamodel change. 
-
 ### Extending the GraphQL schema
 
 Remember the process of schema-driven development? It all starts with extending your schema definition with the new operations that you want to add to the API - in this case a `signup` and `login` mutation.


### PR DESCRIPTION
I was following along with the post-deploy instructions when I noticed this in the CLI
```
Warning: The `prisma generate` command was executed twice. Since Prisma 1.31, the Prisma client is generated automatically after running `prisma deploy`. It is not necessary to generate it via a `post-deploy` hook any more, you can therefore remove the hook if you do not need it otherwise.
```

Seems like this would be worth removing to keep the tutorial up to date with the current state of tooling.